### PR TITLE
build: add build script

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -15,7 +15,7 @@ describe('initialize', () => {
 
   test('enabled mock', async () => {
     const models = {}
-    const router = []
+    const router:any[] = []
 
     db = (await mockServer(client, models, router)).db
     await expect(client.get('/')).rejects.toHaveProperty('response.status', 404)

--- a/package-lock.json
+++ b/package-lock.json
@@ -269,6 +269,17 @@
         "realpath-native": "^1.1.0",
         "rimraf": "^2.5.4",
         "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@jest/environment": {
@@ -2737,6 +2748,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -4205,9 +4225,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "axios-mock-server",
   "version": "0.0.1",
   "description": "RESTful mock server using axios-mock-adapter",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
+    "build": "rimraf dist && tsc --project tsconfig.build.json",
     "test": "jest",
     "test:watch": "npm test -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/nedb": "^1.8.8",
     "axios": "^0.19.0",
     "jest": "^24.8.0",
+    "rimraf": "^3.0.0",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"

--- a/src/AsyncNedb.ts
+++ b/src/AsyncNedb.ts
@@ -17,12 +17,12 @@ export default class extends nedb {
 
   public asyncFind<T>(query: any, projection?: T): Promise<Array<T>> {
     if (projection) {
-      return new Promise((resolve, reject) => super.find(query, projection, (err, documents) => {
+      return new Promise((resolve, reject) => super.find<T>(query, projection, (err, documents) => {
         if (err) reject(err)
         else resolve(documents)
       }))
     } else {
-      return new Promise((resolve, reject) => super.find(query, (err, documents) => {
+      return new Promise((resolve, reject) => super.find<T>(query, (err, documents) => {
         if (err) reject(err)
         else resolve(documents)
       }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,9 @@ export default async (client: AxiosInstance, models: MockModels, router: MockRou
 
     methodsList.forEach((method) => {
       if (r.methods[method]) {
-        (mock[`on${method[0].toUpperCase()}${method.slice(1)}`] as typeof mock.onAny)(regPath).reply(async ({ url, baseURL, data = '{}' }) =>
+        type MockMethod = 'onGet'| 'onPost'| 'onPut'| 'onDelete'| 'onOptions'| 'onHead'| 'onPatch'
+        const key =`on${method[0].toUpperCase()}${method.slice(1)}` as Extract<MockMethod, keyof typeof mock>
+        (mock[key])(regPath).reply(async ({ url, baseURL, data = '{}' }) =>
           [200, await r.methods[method]!(db, createParams(r.path, url, baseURL), JSON.parse(data))]
         )
       }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "outDir": "dist",
     "paths": {
       "~/*": ["./*"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,15 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "experimentalDecorators": true,
-    "allowJs": true,
-    "sourceMap": true,
-    "strict": true,
-    "noImplicitAny": false,
-    "noEmit": true,
     "baseUrl": ".",
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
     "paths": {
       "~/*": ["./*"]
-    }
+    },
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "esnext"
   }
 }


### PR DESCRIPTION
[TypeScript](https://www.typescriptlang.org/) のコードをコンパイルする npm run-script を追加しました。  
`npm run build` で `dist` ディレクトリにコンパイル後のファイルが書き出されます。

`tsconfig.json` についても以下の設定を変更しています。

- `compilerOptions.outDir` の追加
- `compilerOptions.module` の値を `esnext` から `commonjs` に変更
- `compilerOptions` から `allowJs`, `experimentalDecorators`, `noEmit`, `noImplicitAny` を削除
- `compilerOptions` のオプションの順番を昇順で並び替え

`compilerOptions.noImplicitAny` を削除したことにより以下のエラーが発生したため f6ef5a2636dc21f3529dbc535bc5eb82f2627bce で修正しています。

```sh
axios-mock-server $ node node_modules/.bin/tsc

__tests__/index.spec.ts:18:11 - error TS7034: Variable 'router' implicitly has type 'any[]' in some locations where its type cannot be determined.

18     const router = []
             ~~~~~~

__tests__/index.spec.ts:20:44 - error TS7005: Variable 'router' implicitly has an 'any[]' type.

20     db = (await mockServer(client, models, router)).db
                                              ~~~~~~

src/AsyncNedb.ts:25:66 - error TS7006: Parameter 'err' implicitly has an 'any' type.

25       return new Promise((resolve, reject) => super.find(query, (err, documents) => {
                                                                    ~~~

src/AsyncNedb.ts:25:71 - error TS7006: Parameter 'documents' implicitly has an 'any' type.

25       return new Promise((resolve, reject) => super.find(query, (err, documents) => {
                                                                         ~~~~~~~~~

src/index.ts:80:10 - error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'MockAdapter'.
  No index signature with a parameter of type 'string' was found on type 'MockAdapter'.

80         (mock[`on${method[0].toUpperCase()}${method.slice(1)}`] as typeof mock.onAny)(regPath).reply(async ({ url, baseURL, data = '{}' }) =>
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 5 errors.
```
