### PR TITLE
ci: add steps to export coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,10 @@ jobs:
           cache_version: << parameters.cache_version >>
       - run:
           name: Run tests
-          command: npm test
+          command: npm test -- --coverage
+      - run:
+          name: Report coverage results
+          command: npx codecov
   publish:
     executor:
       name: default

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # axios-mock-server
 
-RESTful mock server using axios-mock-adapter
+[![npm version](https://img.shields.io/npm/v/axios-mock-server)](https://www.npmjs.com/package/axios-mock-server)
+[![CircleCI](https://img.shields.io/circleci/build/github/m-mitsuhide/axios-mock-server.svg?label=test)](https://circleci.com/gh/m-mitsuhide/axios-mock-server)
+[![Codecov](https://img.shields.io/codecov/c/github/m-mitsuhide/axios-mock-server.svg)](https://codecov.io/gh/m-mitsuhide/axios-mock-server)
+![License](https://img.shields.io/npm/l/axios-mock-server)
+
+RESTful mock server using axios-mock-adapter.
 
 ## Usage
 


### PR DESCRIPTION
[Codecov](https://codecov.io/) にカバレッジのデータをアップロードするステップを追加しました。