### PR TITLE
ci: fix publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,16 +47,9 @@ jobs:
   test:
     executor:
       name: default
-    parameters:
-      cache_key:
-        type: string
-      cache_version:
-        type: string
     steps:
       - checkout
-      - install_packages:
-          cache_key: << parameters.cache_key >>
-          cache_version: << parameters.cache_version >>
+      - install_packages
       - run:
           name: Run lint
           command: npm run lint
@@ -75,6 +68,10 @@ jobs:
         enum: ["latest"]
     steps:
       - checkout
+      - install_packages
+      - run:
+          name: Build scripts
+          command: npm run build
       - publish_npm_package:
           npm_dist_tag: << parameters.npm_dist_tag >>
   audit:
@@ -90,8 +87,6 @@ workflows:
   commit:
     jobs:
       - test:
-          cache_key: package-lock.json
-          cache_version: v1
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+){2}$/


### PR DESCRIPTION
[CircleCI](https://circleci.com) で `npm publish` の前に [TypeScript](https://www.typescriptlang.org/) のファイルをコンパイルできていなかったのを修正しました。