### PR TITLE
chore: automate dependency updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,18 @@
+version: 1
+
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    version_requirement_updates: "increase_versions"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "semver:minor"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"


### PR DESCRIPTION
依存パッケージの更新のために [Dependabot](https://dependabot.com/) の設定ファイルを追加しました。

- Documentation: <https://dependabot.com/docs/config-file/>
- Validator: <https://dependabot.com/docs/config-file/validator/>
- Schedule: daily
- `dependencies`: patch version までの更新を自動でマージ
- `devDependencies`: minor version までの更新を自動でマージ
