### PR TITLE
docs: add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a bug in axios-mock-server
+---
+
+## Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Environment
+
+- **axios-mock-server version:**
+  <!-- e.g. v1.0.0 -->
+  `vX.X.X`
+- **OS:**
+  <!-- Update "[ ]" to "[x]" to check a box. -->
+  - [ ] Linux
+  - [ ] Windows
+  - [ ] macOS
+- **Node.js version:**
+  <!-- run `node -v` and paste output below. -->
+  ``
+- **npm version:**
+  <!-- run `npm -v` and paste output below. -->
+  ``
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest a feature for axios-mock-server
+---
+
+## Description
+
+<!-- A clear and concise description of the problem or missing capability. -->
+
+## Describe the solution you'd like
+
+<!-- If you have a solution in mind, please describe it. -->
+
+## Describe alternatives you've considered
+
+<!-- Have you considered any alternative solutions or workarounds? -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Types of changes
+
+What kind of change does this PR introduce? (check at least one)
+
+<!-- Update "[ ]" to "[x]" to check a box. -->
+
+- [ ] Breaking change
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update
+- [ ] Refactoring
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Documentation content changes
+- [ ] Other... Please describe:
+
+## Description
+
+<!-- link to a relevant issue. -->
+
+Issue Number: N/A
+
+<!--- Describe your changes in detail. -->

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "singleQuote": true,
   "overrides": [
     {
-      "files": ["*.yml"],
+      "files": ["*.md", "*.yml"],
       "options": {
         "singleQuote": false
       }


### PR DESCRIPTION
[Angular](https://angular.io/) などを参考に [GitHub](https://github.com/) で利用できるテンプレートを追加しました。

- Previews:
  - [`bug_report.md`](https://github.com/m-mitsuhide/axios-mock-server/blob/add-docs/.github/ISSUE_TEMPLATE/bug_report.md)
  - [`feature_request.md`](https://github.com/m-mitsuhide/axios-mock-server/blob/add-docs/.github/ISSUE_TEMPLATE/feature_request.md)
  - [`pull_request_template.md`](https://github.com/m-mitsuhide/axios-mock-server/blob/add-docs/.github/pull_request_template.md)
- References:
  - [Issueとプルリクエストのテンプレートについて - GitHub ヘルプ](https://help.github.com/ja/articles/about-issue-and-pull-request-templates)
  - `bug_report.md`
    - [creativecommons/.github](https://github.com/creativecommons/.github/blob/master/.github/ISSUE_TEMPLATE/bug_report.md)
    - [angular/angular](https://github.com/angular/angular/blob/master/.github/ISSUE_TEMPLATE/1-bug-report.md)
  - `feature_request.md`
    - [creativecommons/.github](https://github.com/creativecommons/.github/blob/master/.github/ISSUE_TEMPLATE/feature_request.md)
    - [angular/angular](https://github.com/angular/angular/blob/master/.github/ISSUE_TEMPLATE/2-feature-request.md)
  - `pull_request_template.md`
    - [angular/angular](https://github.com/angular/angular/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
    - [nuxt/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/.github/PULL_REQUEST_TEMPLATE.md)
    - [vuejs/vue](https://github.com/vuejs/vue/blob/dev/.github/PULL_REQUEST_TEMPLATE.md)
