### PR TITLE
refactor: use require function without default in CommonJS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,8 @@ import asyncResponse from './asyncResponse'
 export { asyncResponse, MockServer, MockRoute, HttpMethod, MockResponse, MockMethods }
 
 export default (route?: MockRoute, client?: AxiosInstance) => new MockServer(route, client)
+
+/* eslint-disable dot-notation */
+module.exports = exports['default']
+module.exports.default = exports['default']
+module.exports.asyncResponse = asyncResponse


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->

Issue Number: N/A

<!--- Describe your changes in detail. -->

CommonJS の環境で axios-mock-server を読み込む場合、`require('axios-mock-server').default` の `.default` がなくても動作するように変更しました。

Reference: [59naga/babel-plugin-add-module-exports: 【v0.2 no longer maintained】 Fix babel/babel#2212 - Follow the babel@5 behavior for babel@6](https://github.com/59naga/babel-plugin-add-module-exports)